### PR TITLE
Improve dashboard plot responsiveness and scanning setup

### DIFF
--- a/run.py
+++ b/run.py
@@ -89,6 +89,21 @@ def homepage():
   # run html template
   return render_template('alignment.html', context=context)
 
+
+@app.route("/autoalignment")
+def autoalignment_mode():
+
+  # empty plots
+  plot_lidar_signal = plotly_plot.plotly_empty_signal("raw")
+  plot_lidar_range_correction = plotly_plot.plotly_empty_signal("rangecorrected")
+
+  context = {"plot_lidar_signal": plot_lidar_signal,
+             "plot_lidar_range_correction": plot_lidar_range_correction,
+             "globalconfig": globalconfig
+            }
+
+  return render_template('autoalignment.html', context=context)
+
 @app.route("/acquisition")
 def acquisition_mode():
 

--- a/run.py
+++ b/run.py
@@ -54,7 +54,10 @@ globalconfig = {
                   "motor_port" : 'COM4',
                   "motor_resolution" : 0.1,
                   "motor_steps" : 10,
-                  "motor_feed_rate" : 50
+                  "motor_feed_rate" : 50,
+                  "corr_range_init" : 5000,
+                  "corr_range_final" : 10000,
+                  "grid_min_resolution" : 0.1
                  }
 
 #----------- INI FILES -----------

--- a/run.py
+++ b/run.py
@@ -57,7 +57,16 @@ globalconfig = {
                   "motor_feed_rate" : 50,
                   "corr_range_init" : 5000,
                   "corr_range_final" : 10000,
-                  "grid_min_resolution" : 0.1
+                  "grid_min_resolution" : 0.1,
+                  "scan_rows" : 8,
+                  "scan_cols" : 8,
+                  "scan_step_x" : 1.000,
+                  "scan_step_y" : 1.000,
+                  "scan_feed" : 50,
+                  "scan_pattern" : "raster",
+                  "scan_reverse" : False,
+                  "scan_delay" : 0.0,
+                  "scan_on_fail" : "retry"
                  }
 
 #----------- INI FILES -----------
@@ -681,6 +690,57 @@ def motor_controls():
     motor.init_incremental(feed_mm_min=100.0)
     motor.set_zero()  # Set current position as home
     motor.close()
+
+  response = make_response(json.dumps(globalconfig))
+  response.content_type = 'application/json'
+  return response
+
+@app.route('/scan_setup', methods=['GET','POST'])
+def scan_setup_controls():
+  field_selected = request.args['selected']
+  data_input = request.args['input']
+
+  print("Scan setup action: " + field_selected + ", input: " + data_input)
+
+  integer_fields = ["scan_rows", "scan_cols", "scan_feed"]
+  float_fields = ["scan_step_x", "scan_step_y", "scan_delay"]
+  pattern_options = ["raster", "zigzag", "spiral"]
+  on_fail_options = ["retry", "skip", "abort"]
+
+  if field_selected in integer_fields and data_input.isdigit():
+    value = int(data_input)
+    if field_selected in ["scan_rows", "scan_cols"] and value > 2:
+      globalconfig[field_selected] = value
+    if field_selected == "scan_feed" and value > 0:
+      globalconfig[field_selected] = value
+
+  if field_selected in float_fields and data_input.replace('.','',1).isdigit():
+    value = float(data_input)
+    if field_selected in ["scan_step_x", "scan_step_y"] and value > 0:
+      globalconfig[field_selected] = round(value, 3)
+    if field_selected == "scan_delay" and value >= 0:
+      globalconfig[field_selected] = value
+
+  if field_selected == "scan_steps":
+    scan_steps = json.loads(data_input)
+    if len(scan_steps) == 2:
+      step_x = scan_steps[0]
+      step_y = scan_steps[1]
+      if str(step_x).replace('.','',1).isdigit() and str(step_y).replace('.','',1).isdigit():
+        step_x = float(step_x)
+        step_y = float(step_y)
+        if step_x > 0 and step_y > 0:
+          globalconfig["scan_step_x"] = round(step_x, 3)
+          globalconfig["scan_step_y"] = round(step_y, 3)
+
+  if field_selected == "scan_pattern" and data_input in pattern_options:
+    globalconfig[field_selected] = data_input
+
+  if field_selected == "scan_reverse" and data_input in ["true", "false", "True", "False"]:
+    globalconfig[field_selected] = data_input.lower() == "true"
+
+  if field_selected == "scan_on_fail" and data_input in on_fail_options:
+    globalconfig[field_selected] = data_input
 
   response = make_response(json.dumps(globalconfig))
   response.content_type = 'application/json'

--- a/templates/acquisition.html
+++ b/templates/acquisition.html
@@ -1,8 +1,18 @@
 {% extends "layout.html" %}
 {% block script %}
-<!-- 
-put your custom script or styling here
--->
+<style>
+    .plot-host {
+        width: 100%;
+        height: clamp(320px, 48vh, 560px);
+        min-width: 0;
+    }
+
+    @media (max-width: 992px) {
+        .plot-host {
+            height: clamp(280px, 52vh, 460px);
+        }
+    }
+</style>
 {% endblock script %}
 
 <!-- Mode legend -->
@@ -200,22 +210,54 @@ put your custom script or styling here
     <!-- ./col -->
 </div>
 
-<!-- Plotly plot placeholder -->
-<div class="container-fluid">
-      <div class="row">
-          <!-- LiDAR signal plot-->
-          <div class="chart" id="plotly-lidar-signal">
-          </div>
-      </div>
-      <hr>
-  </div>
+<div class="container-fluid pt-2">
+    <div id="plotly-lidar-signal" class="plot-host"></div>
 </div>
 
-<!-- Script to execute the Json ( we can create it also with looping) -->
 <script>
-//Parse your Json variable here
-var graphs = {{ context.plot_multiple_lidar_signal | safe }};
-Plotly.plot('plotly-lidar-signal', graphs, {});
+var plotlyConfig = {responsive: true, displaylogo: false};
+
+function responsiveLayout(baseLayout, overrides) {
+    var layout = Object.assign({}, baseLayout || {}, overrides || {});
+    delete layout.width;
+    delete layout.height;
+    layout.autosize = true;
+    return layout;
+}
+
+function drawResponsivePlot(targetId, figure, layoutOverrides) {
+    var traces = Array.isArray(figure) ? figure : (figure.data || []);
+    var layout = responsiveLayout(Array.isArray(figure) ? {} : figure.layout, layoutOverrides);
+    Plotly.newPlot(targetId, traces, layout, plotlyConfig);
+}
+
+drawResponsivePlot('plotly-lidar-signal', {{ context.plot_multiple_lidar_signal | safe }}, {
+    title: null,
+    margin: {t: 32, r: 24, b: 56, l: 64}
+});
+
+function resizeAcquisitionPlots() {
+    var el = document.getElementById('plotly-lidar-signal');
+    if (el) {
+        Plotly.Plots.resize(el);
+    }
+}
+
+window.addEventListener('resize', resizeAcquisitionPlots);
+setTimeout(resizeAcquisitionPlots, 150);
+
+if ('ResizeObserver' in window) {
+    var acquisitionResizeObserver = new ResizeObserver(function() {
+        window.requestAnimationFrame(resizeAcquisitionPlots);
+    });
+    acquisitionResizeObserver.observe(document.getElementById('plotly-lidar-signal'));
+}
+
+document.addEventListener('click', function(event) {
+    if (event.target.closest('[data-widget="pushmenu"]')) {
+        setTimeout(resizeAcquisitionPlots, 350);
+    }
+});
 </script>
 
 <script>
@@ -237,4 +279,3 @@ document.getElementById('laser_port_input').value = globalconfig["laser_port"];
 
 
 {% endblock my_content %}
-

--- a/templates/alignment.html
+++ b/templates/alignment.html
@@ -1,8 +1,55 @@
 {% extends "layout.html" %}
 {% block script %}
-<!-- 
-put your custom script or styling here
--->
+<style>
+    .alignment-plots {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1rem;
+        align-items: stretch;
+    }
+
+    .alignment-plot-wide {
+        margin-top: 1rem;
+    }
+
+    .alignment-card {
+        height: 100%;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .alignment-card .card-header {
+        padding: .5rem .75rem;
+    }
+
+    .alignment-card .card-body {
+        flex: 1 1 auto;
+        min-height: 0;
+        padding: .5rem;
+    }
+
+    .plot-host {
+        width: 100%;
+        height: clamp(280px, 32vh, 420px);
+        min-width: 0;
+    }
+
+    .plot-host-wide {
+        height: clamp(320px, 42vh, 520px);
+    }
+
+    @media (max-width: 992px) {
+        .alignment-plots {
+            grid-template-columns: 1fr;
+        }
+
+        .plot-host,
+        .plot-host-wide {
+            height: clamp(260px, 42vh, 420px);
+        }
+    }
+</style>
 {% endblock script %}
 
 <!-- Mode legend -->
@@ -543,45 +590,79 @@ put your custom script or styling here
     <!-- ./col -->
     <!-- ./col -->
 </div>
-<!-- Plotly plot placeholder -->
-<div class="container-fluid">
-    <div class="row">
-        <div class="column">
-            <!-- LiDAR signal with range correction plot-->
-            <div id="plotly-lidar-range-correction"></div>
+<div class="container-fluid pt-2">
+    <div class="alignment-plots">
+        <div class="card alignment-card">
+            <div class="card-header"><b>Range corrected LiDAR signal</b></div>
+            <div class="card-body"><div id="plotly-lidar-range-correction" class="plot-host"></div></div>
         </div>
-        <!-- <hr class="vertical" /> -->
-        <div class="column">
-            <!-- RMS error fitting plot-->
-            <div id="plotly-lidar-rms"></div>
+        <div class="card alignment-card">
+            <div class="card-header"><b>Pearson correlation coefficient</b></div>
+            <div class="card-body"><div id="plotly-lidar-rms" class="plot-host"></div></div>
         </div>
     </div>
-    <hr>
-    <div class="row">
-        <!-- LiDAR signal plot-->
-        <div class="chart" id="plotly-lidar-signal">
+    <div class="alignment-plot-wide">
+        <div class="card alignment-card">
+            <div class="card-header"><b>Raw LiDAR signal</b></div>
+            <div class="card-body"><div id="plotly-lidar-signal" class="plot-host plot-host-wide"></div></div>
         </div>
     </div>
 </div>
-</div>
-
-<!-- Script to execute the Json ( we can create it also with looping) -->
-<script>
-//Parse your Json variable here
-var graphs = {{ context.plot_lidar_signal | safe }};
-Plotly.plot('plotly-lidar-signal', graphs, {});
-</script>
 
 <script>
-//Parse your Json variable here
-var graphs = {{ context.plot_lidar_range_correction | safe }};
-Plotly.plot('plotly-lidar-range-correction', graphs, {});
-</script>
+var plotlyConfig = {responsive: true, displaylogo: false};
 
-<script>
-//Parse your Json variable here
-var graphs = {{ context.plot_lidar_rms | safe }};
-Plotly.plot('plotly-lidar-rms', graphs, {});
+function responsiveLayout(baseLayout, overrides) {
+    var layout = Object.assign({}, baseLayout || {}, overrides || {});
+    delete layout.width;
+    delete layout.height;
+    layout.autosize = true;
+    return layout;
+}
+
+function drawResponsivePlot(targetId, figure, layoutOverrides) {
+    var traces = Array.isArray(figure) ? figure : (figure.data || []);
+    var layout = responsiveLayout(Array.isArray(figure) ? {} : figure.layout, layoutOverrides);
+    Plotly.newPlot(targetId, traces, layout, plotlyConfig);
+}
+
+drawResponsivePlot('plotly-lidar-range-correction', {{ context.plot_lidar_range_correction | safe }}, {
+    margin: {t: 104, r: 24, b: 64, l: 64}
+});
+drawResponsivePlot('plotly-lidar-rms', {{ context.plot_lidar_rms | safe }}, {
+    margin: {t: 76, r: 24, b: 56, l: 64}
+});
+drawResponsivePlot('plotly-lidar-signal', {{ context.plot_lidar_signal | safe }}, {
+    title: null,
+    margin: {t: 32, r: 24, b: 56, l: 64}
+});
+
+function resizeAlignmentPlots() {
+    ['plotly-lidar-range-correction', 'plotly-lidar-rms', 'plotly-lidar-signal'].forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) {
+            Plotly.Plots.resize(el);
+        }
+    });
+}
+
+window.addEventListener('resize', resizeAlignmentPlots);
+setTimeout(resizeAlignmentPlots, 150);
+
+if ('ResizeObserver' in window) {
+    var alignmentResizeObserver = new ResizeObserver(function() {
+        window.requestAnimationFrame(resizeAlignmentPlots);
+    });
+    document.querySelectorAll('.plot-host').forEach(function(el) {
+        alignmentResizeObserver.observe(el);
+    });
+}
+
+document.addEventListener('click', function(event) {
+    if (event.target.closest('[data-widget="pushmenu"]')) {
+        setTimeout(resizeAlignmentPlots, 350);
+    }
+});
 </script>
 
 <script>

--- a/templates/autoalignment.html
+++ b/templates/autoalignment.html
@@ -35,10 +35,20 @@
         height: 34vh;
     }
 
+    .plot-host-square {
+        width: 100%;
+        aspect-ratio: 1 / 1;
+        min-height: 320px;
+    }
+
     @media (max-width: 992px) {
         .plot-host {
             min-height: 260px;
             height: 36vh;
+        }
+
+        .plot-host-square {
+            min-height: 280px;
         }
     }
 </style>
@@ -222,6 +232,23 @@
                     </div>
                 </div>
             </div>
+            <label><b style="color:white">Correlation range [m]:</b></label>
+            <div class="form-row align-items-center">
+                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="corr_range_init_input" placeholder="Initial"></div>
+                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="corr_range_final_input" placeholder="Final"></div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="corr_range_apply" value="corr_range">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">Δ grid</div></div>
+                        <input type="text" class="form-control" id="grid_min_resolution_input" placeholder="Min resolution between points">
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="grid_min_resolution_apply" value="grid_min_resolution">Apply</button></div>
+            </div>
+            <small style="color:#ced4da;">Se requiere una resolución mínima entre puntos consecutivos para muestreo en grilla X/Y.</small>
+            <br>
             <button type="button" class="btn btn-outline-success btn-sm" id="autoalign_start_btn" value="autoalign_start">START AUTOALIGN</button>
             <button type="button" class="btn btn-outline-danger btn-sm" id="autoalign_stop_btn" value="autoalign_stop">STOP</button>
         </li>
@@ -258,7 +285,7 @@
         <div class="col-md-6">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Range corrected LiDAR signal</b></div>
-                <div class="card-body"><div id="plotly-lidar-range-correction" class="plot-host"></div></div>
+                <div class="card-body"><div id="plotly-lidar-range-correction" class="plot-host-square"></div></div>
             </div>
         </div>
         <div class="col-md-6">
@@ -273,7 +300,7 @@
         <div class="col-md-6">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Raw LiDAR signal</b></div>
-                <div class="card-body"><div id="plotly-lidar-signal" class="plot-host"></div></div>
+                <div class="card-body"><div id="plotly-lidar-signal" class="plot-host-square"></div></div>
             </div>
         </div>
         <div class="col-md-6">
@@ -286,13 +313,33 @@
 </div>
 
 <script>
-var signalGraph = {{ context.plot_lidar_signal | safe }};
 var correctedGraph = {{ context.plot_lidar_range_correction | safe }};
 var plotlyConfig = {responsive: true, displaylogo: false};
 var standardMargins = {t: 28, r: 24, b: 48, l: 56};
 
-Plotly.newPlot('plotly-lidar-signal', signalGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
 Plotly.newPlot('plotly-lidar-range-correction', correctedGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
+
+var xGrid = [-2, -1, 0, 1, 2];
+var yGrid = [-2, -1, 0, 1, 2];
+var zGrid = yGrid.map(function() { return xGrid.map(function() { return null; }); });
+var rawHeatmap = [{
+    type: 'heatmap',
+    x: xGrid,
+    y: yGrid,
+    z: zGrid,
+    colorscale: 'Viridis',
+    zmin: -1,
+    zmax: 1,
+    colorbar: {title: 'Pearson r'}
+}];
+var rawHeatmapLayout = {
+    title: 'X/Y scan grid (Pearson map)',
+    margin: {t: 38, r: 24, b: 48, l: 56},
+    xaxis: {title: 'Motor X position', scaleanchor: 'y', scaleratio: 1},
+    yaxis: {title: 'Motor Y position'},
+    autosize: true
+};
+Plotly.newPlot('plotly-lidar-signal', rawHeatmap, rawHeatmapLayout, plotlyConfig);
 
 var pearsonTrace = [{
     x: [],
@@ -368,5 +415,8 @@ document.getElementById('raw_limits_init_input').value = globalconfig["raw_limit
 document.getElementById('raw_limits_final_input').value = globalconfig["raw_limits_final"];
 document.getElementById('pearson_target_input').value = "0.98";
 document.getElementById('max_iter_input').value = "25";
+document.getElementById('corr_range_init_input').value = globalconfig["corr_range_init"];
+document.getElementById('corr_range_final_input').value = globalconfig["corr_range_final"];
+document.getElementById('grid_min_resolution_input').value = globalconfig["grid_min_resolution"];
 </script>
 {% endblock my_content %}

--- a/templates/autoalignment.html
+++ b/templates/autoalignment.html
@@ -28,6 +28,19 @@
         font-weight: 700;
         font-size: 1.1rem;
     }
+
+    .plot-host {
+        width: 100%;
+        min-height: 300px;
+        height: 34vh;
+    }
+
+    @media (max-width: 992px) {
+        .plot-host {
+            min-height: 260px;
+            height: 36vh;
+        }
+    }
 </style>
 {% endblock script %}
 
@@ -245,13 +258,13 @@
         <div class="col-md-6">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Range corrected LiDAR signal</b></div>
-                <div class="card-body"><div id="plotly-lidar-range-correction"></div></div>
+                <div class="card-body"><div id="plotly-lidar-range-correction" class="plot-host"></div></div>
             </div>
         </div>
         <div class="col-md-6">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Pearson coefficient evolution</b></div>
-                <div class="card-body"><div id="plotly-pearson"></div></div>
+                <div class="card-body"><div id="plotly-pearson" class="plot-host"></div></div>
             </div>
         </div>
     </div>
@@ -260,13 +273,13 @@
         <div class="col-md-6">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Raw LiDAR signal</b></div>
-                <div class="card-body"><div id="plotly-lidar-signal"></div></div>
+                <div class="card-body"><div id="plotly-lidar-signal" class="plot-host"></div></div>
             </div>
         </div>
         <div class="col-md-6">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Laser spot in telescope FOV (guide)</b></div>
-                <div class="card-body"><div id="plotly-spot-polar"></div></div>
+                <div class="card-body"><div id="plotly-spot-polar" class="plot-host"></div></div>
             </div>
         </div>
     </div>
@@ -274,10 +287,12 @@
 
 <script>
 var signalGraph = {{ context.plot_lidar_signal | safe }};
-Plotly.plot('plotly-lidar-signal', signalGraph, {});
-
 var correctedGraph = {{ context.plot_lidar_range_correction | safe }};
-Plotly.plot('plotly-lidar-range-correction', correctedGraph, {});
+var plotlyConfig = {responsive: true, displaylogo: false};
+var standardMargins = {t: 28, r: 24, b: 48, l: 56};
+
+Plotly.newPlot('plotly-lidar-signal', signalGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
+Plotly.newPlot('plotly-lidar-range-correction', correctedGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
 
 var pearsonTrace = [{
     x: [],
@@ -291,7 +306,7 @@ var pearsonLayout = {
     yaxis: {title: 'r', range: [-1, 1]},
     xaxis: {title: 'Iteration'}
 };
-Plotly.newPlot('plotly-pearson', pearsonTrace, pearsonLayout);
+Plotly.newPlot('plotly-pearson', pearsonTrace, pearsonLayout, plotlyConfig);
 
 var polarGuide = [{
     type: 'scatterpolar',
@@ -315,7 +330,26 @@ var polarLayout = {
     },
     showlegend: false
 };
-Plotly.newPlot('plotly-spot-polar', polarGuide, polarLayout);
+Plotly.newPlot('plotly-spot-polar', polarGuide, polarLayout, plotlyConfig);
+
+function resizeAutoalignPlots() {
+    ['plotly-lidar-signal', 'plotly-lidar-range-correction', 'plotly-pearson', 'plotly-spot-polar'].forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) {
+            Plotly.Plots.resize(el);
+        }
+    });
+}
+
+window.addEventListener('resize', resizeAutoalignPlots);
+setTimeout(resizeAutoalignPlots, 150);
+
+// Also refresh plot sizes after sidebar collapse/expand transitions
+document.addEventListener('click', function(event) {
+    if (event.target.closest('[data-widget="pushmenu"]')) {
+        setTimeout(resizeAutoalignPlots, 350);
+    }
+});
 </script>
 
 <script>

--- a/templates/autoalignment.html
+++ b/templates/autoalignment.html
@@ -1,0 +1,338 @@
+{% extends "layout.html" %}
+{% block script %}
+<style>
+    .autoalign-card .card-header {
+        padding: .5rem .75rem;
+    }
+
+    .autoalign-summary {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: .75rem;
+    }
+
+    .summary-box {
+        border: 1px solid #dee2e6;
+        border-radius: .25rem;
+        padding: .5rem .75rem;
+        background: #fff;
+    }
+
+    .summary-box .label {
+        display: block;
+        color: #6c757d;
+        font-size: .8rem;
+    }
+
+    .summary-box .value {
+        font-weight: 700;
+        font-size: 1.1rem;
+    }
+</style>
+{% endblock script %}
+
+{% block mode %}
+<a class="d-block">
+    <i class="nav-icon fas fa-angle-right"></i>
+    <b>Autoalignment</b> Mode
+</a>
+{% endblock mode %}
+
+{% block sidebar %}
+<!-- Licel controls -->
+<li class="nav-item has-treeview menu-open">
+    <a href="#" class="nav-link">
+        <i class="nav-icon fas fa-desktop"></i>
+        <p>Licel controls<i class="right fas fa-angle-left"></i></p>
+    </a>
+    <ul class="nav nav-treeview">
+        <li class="nav-item">
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">Ch</div></div>
+                        <input type="text" class="form-control" id="channel_input" placeholder="Channel">
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="channel_apply" value="channel">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">Sec</div></div>
+                        <input type="text" class="form-control" id="acq_time_input" placeholder="Acq. Time">
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="acq_time_apply" value="acq_time">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">Bin</div></div>
+                        <input type="text" class="form-control" id="bin_offset_input" placeholder="Bin offset">
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="bin_offset_apply" value="bin_offset">Apply</button></div>
+            </div>
+        </li>
+        <li class="nav-item">
+            <button type="button" class="btn btn-outline-success btn-sm" id="startbtn" value="start">START</button>
+            <button type="button" class="btn btn-outline-danger btn-sm" id="stopbtn" value="stop">STOP</button>
+            <button type="button" class="btn btn-outline-primary btn-sm" id="oneshotbtn" value="oneshot">SINGLE SHOT</button>
+        </li>
+    </ul>
+</li>
+
+<!-- Plot controls -->
+<li class="nav-item has-treeview menu-closed">
+    <a href="#" class="nav-link ">
+        <i class="nav-icon fas fa-chart-line"></i>
+        <p>Plots controls<i class="right fas fa-angle-left"></i></p>
+    </a>
+    <ul class="nav nav-treeview">
+        <li class="nav-item">
+            <label><b style="color:white">Range corrected [m]:</b></label>
+            <div class="form-row align-items-center">
+                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="rc_limits_init_input" placeholder="Initial"></div>
+                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="rc_limits_final_input" placeholder="Final"></div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="rc_limits_apply" value="rc_limits">Apply</button></div>
+            </div>
+            <label><b style="color:white">Raw signal [m]:</b></label>
+            <div class="form-row align-items-center">
+                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="raw_limits_init_input" placeholder="Initial"></div>
+                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="raw_limits_final_input" placeholder="Final"></div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="raw_limits_apply" value="raw_limits">Apply</button></div>
+            </div>
+        </li>
+    </ul>
+</li>
+
+<!-- Laser controls -->
+<li class="nav-item has-treeview menu-closed">
+    <a href="#" class="nav-link ">
+        <i class="nav-icon fas fa-atom"></i>
+        <p>Laser controls<i class="right fas fa-angle-left"></i></p>
+    </a>
+    <ul class="nav nav-treeview">
+        <li class="nav-item">
+            <div class="form-row align-items-center">
+                <div class="col-sm-7 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">></div></div>
+                        <input type="text" class="form-control" id="laser_port_input" placeholder="Serial port">
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="button" class="btn btn-outline-success btn-sm" id="laser_startbtn" value="laser_start">ON</button></div>
+                <div class="col-sm-2 my-1"><button type="button" class="btn btn-outline-danger btn-sm" id="laser_stopbtn" value="laser_stop">OFF</button></div>
+            </div>
+        </li>
+    </ul>
+</li>
+
+<!-- Motor controls -->
+<li class="nav-item has-treeview menu-closed">
+    <a href="#" class="nav-link ">
+        <i class="nav-icon fas fa-cogs"></i>
+        <p>Motor PAP controls<i class="right fas fa-angle-left"></i></p>
+    </a>
+    <ul class="nav nav-treeview">
+        <li class="nav-item">
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group"><div class="input-group-prepend"><div class="input-group-text">></div></div>
+                        <input type="text" class="form-control" id="motor_port_input" placeholder="Serial port"></div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="motor_port_apply" value="motor_port">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group"><div class="input-group-prepend"><div class="input-group-text">Step size</div></div>
+                        <input type="text" class="form-control" id="motor_resolution_input" placeholder="Resolution"></div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="motor_resolution_apply" value="motor_resolution">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group"><div class="input-group-prepend"><div class="input-group-text">N° steps</div></div>
+                        <input type="text" class="form-control" id="motor_steps_input" placeholder="Steps"></div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="motor_steps_apply" value="motor_steps">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group"><div class="input-group-prepend"><div class="input-group-text">Feed rate</div></div>
+                        <input type="text" class="form-control" id="motor_feed_rate_input" placeholder="Feed rate"></div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="motor_feed_rate_apply" value="motor_feed_rate">Apply</button></div>
+            </div>
+            <label><b style="color:white; padding-right: 15px;">Motor movements:</b></label>
+            <div class="form-row align-items-center">
+                <div class="col-sm-10 my-1">
+                    <button type="button" class="btn btn-light" id="motor_left_btn" value="motor_left" title="Left"><i class="fas fa-arrow-left"></i></button>
+                    <button type="button" class="btn btn-light" id="motor_right_btn" value="motor_right" title="Right"><i class="fas fa-arrow-right"></i></button>
+                    <button type="button" class="btn btn-light" id="motor_up_btn" value="motor_up" title="Up"><i class="fas fa-arrow-up"></i></button>
+                    <button type="button" class="btn btn-light" id="motor_down_btn" value="motor_down" title="Down"><i class="fas fa-arrow-down"></i></button>
+                    <button type="button" class="btn btn-danger" id="motor_stop_btn" value="motor_stop" title="Stop"><i class="fas fa-stop"></i></button>
+                </div>
+            </div>
+            <div class="form-row align-items-center mt-1">
+                <div class="col-sm-10 my-1">
+                    <button type="button" class="btn btn-outline-primary btn-sm" id="motor_gethome_btn" value="motor_gethome"><i class="fas fa-home"></i> To Home</button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" id="motor_sethome_btn" value="motor_sethome"><i class="fas fa-location-arrow"></i> Set Home</button>
+                </div>
+            </div>
+        </li>
+    </ul>
+</li>
+
+<!-- Autoalignment controls -->
+<li class="nav-item has-treeview menu-closed">
+    <a href="#" class="nav-link ">
+        <i class="nav-icon fas fa-crosshairs"></i>
+        <p>Autoalignment setup<i class="right fas fa-angle-left"></i></p>
+    </a>
+    <ul class="nav nav-treeview">
+        <li class="nav-item">
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">r*</div></div>
+                        <input type="text" class="form-control" id="pearson_target_input" placeholder="Target Pearson">
+                    </div>
+                </div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">N</div></div>
+                        <input type="text" class="form-control" id="max_iter_input" placeholder="Max iterations">
+                    </div>
+                </div>
+            </div>
+            <button type="button" class="btn btn-outline-success btn-sm" id="autoalign_start_btn" value="autoalign_start">START AUTOALIGN</button>
+            <button type="button" class="btn btn-outline-danger btn-sm" id="autoalign_stop_btn" value="autoalign_stop">STOP</button>
+        </li>
+    </ul>
+</li>
+{% endblock sidebar %}
+
+{% block my_content %}
+<div class="container-fluid pt-2">
+    <div class="row mb-2">
+        <div class="col-md-6">
+            <div class="autoalign-summary">
+                <div class="summary-box">
+                    <span class="label">Pearson actual</span>
+                    <span class="value" id="pearson_current_value">--</span>
+                </div>
+                <div class="summary-box">
+                    <span class="label">Mejor Pearson</span>
+                    <span class="value" id="pearson_best_value">--</span>
+                </div>
+                <div class="summary-box">
+                    <span class="label">Posición X (left/right)</span>
+                    <span class="value" id="motor_x_value">0</span>
+                </div>
+                <div class="summary-box">
+                    <span class="label">Posición Y (up/down)</span>
+                    <span class="value" id="motor_y_value">0</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card autoalign-card">
+                <div class="card-header"><b>Range corrected LiDAR signal</b></div>
+                <div class="card-body"><div id="plotly-lidar-range-correction"></div></div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card autoalign-card">
+                <div class="card-header"><b>Pearson coefficient evolution</b></div>
+                <div class="card-body"><div id="plotly-pearson"></div></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card autoalign-card">
+                <div class="card-header"><b>Raw LiDAR signal</b></div>
+                <div class="card-body"><div id="plotly-lidar-signal"></div></div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card autoalign-card">
+                <div class="card-header"><b>Laser spot in telescope FOV (guide)</b></div>
+                <div class="card-body"><div id="plotly-spot-polar"></div></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+var signalGraph = {{ context.plot_lidar_signal | safe }};
+Plotly.plot('plotly-lidar-signal', signalGraph, {});
+
+var correctedGraph = {{ context.plot_lidar_range_correction | safe }};
+Plotly.plot('plotly-lidar-range-correction', correctedGraph, {});
+
+var pearsonTrace = [{
+    x: [],
+    y: [],
+    mode: 'lines+markers',
+    name: 'Pearson r',
+    line: {color: '#17a2b8'}
+}];
+var pearsonLayout = {
+    margin: {t: 20, r: 20, b: 50, l: 50},
+    yaxis: {title: 'r', range: [-1, 1]},
+    xaxis: {title: 'Iteration'}
+};
+Plotly.newPlot('plotly-pearson', pearsonTrace, pearsonLayout);
+
+var polarGuide = [{
+    type: 'scatterpolar',
+    r: [1],
+    theta: [45],
+    mode: 'markers',
+    marker: {size: 13, color: '#dc3545', symbol: 'x'},
+    name: 'Laser spot'
+}];
+var polarLayout = {
+    margin: {t: 20, r: 20, b: 20, l: 20},
+    polar: {
+        radialaxis: {visible: true, range: [0, 5]},
+        angularaxis: {
+            direction: 'clockwise',
+            rotation: 90,
+            tickmode: 'array',
+            tickvals: [0, 90, 180, 270],
+            ticktext: ['UP', 'RIGHT', 'DOWN', 'LEFT']
+        }
+    },
+    showlegend: false
+};
+Plotly.newPlot('plotly-spot-polar', polarGuide, polarLayout);
+</script>
+
+<script>
+var globalconfig = {{ context.globalconfig | safe }};
+document.getElementById('channel_input').value = globalconfig["channel"];
+document.getElementById('acq_time_input').value = globalconfig["acq_time"];
+document.getElementById('bin_offset_input').value = globalconfig["bin_offset"];
+document.getElementById('laser_port_input').value = globalconfig["laser_port"];
+document.getElementById('motor_port_input').value = globalconfig["motor_port"];
+document.getElementById('motor_resolution_input').value = globalconfig["motor_resolution"];
+document.getElementById('motor_steps_input').value = globalconfig["motor_steps"];
+document.getElementById('motor_feed_rate_input').value = globalconfig["motor_feed_rate"];
+document.getElementById('rc_limits_init_input').value = globalconfig["rc_limits_init"];
+document.getElementById('rc_limits_final_input').value = globalconfig["rc_limits_final"];
+document.getElementById('raw_limits_init_input').value = globalconfig["raw_limits_init"];
+document.getElementById('raw_limits_final_input').value = globalconfig["raw_limits_final"];
+document.getElementById('pearson_target_input').value = "0.98";
+document.getElementById('max_iter_input').value = "25";
+</script>
+{% endblock my_content %}

--- a/templates/autoalignment.html
+++ b/templates/autoalignment.html
@@ -305,7 +305,7 @@
         </div>
         <div class="col-md-6">
             <div class="card autoalign-card">
-                <div class="card-header"><b>Laser spot in telescope FOV (guide)</b></div>
+                <div class="card-header"><b>Laser spot in telescope FOV (guide heatmap)</b></div>
                 <div class="card-body"><div id="plotly-spot-polar" class="plot-host"></div></div>
             </div>
         </div>
@@ -319,10 +319,13 @@ var standardMargins = {t: 28, r: 24, b: 48, l: 56};
 
 Plotly.newPlot('plotly-lidar-range-correction', correctedGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
 
+var signalGraph = {{ context.plot_lidar_signal | safe }};
+Plotly.newPlot('plotly-lidar-signal', signalGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
+
 var xGrid = [-2, -1, 0, 1, 2];
 var yGrid = [-2, -1, 0, 1, 2];
 var zGrid = yGrid.map(function() { return xGrid.map(function() { return null; }); });
-var rawHeatmap = [{
+var fovHeatmap = [{
     type: 'heatmap',
     x: xGrid,
     y: yGrid,
@@ -332,14 +335,14 @@ var rawHeatmap = [{
     zmax: 1,
     colorbar: {title: 'Pearson r'}
 }];
-var rawHeatmapLayout = {
+var fovHeatmapLayout = {
     title: 'X/Y scan grid (Pearson map)',
     margin: {t: 38, r: 24, b: 48, l: 56},
     xaxis: {title: 'Motor X position', scaleanchor: 'y', scaleratio: 1},
     yaxis: {title: 'Motor Y position'},
     autosize: true
 };
-Plotly.newPlot('plotly-lidar-signal', rawHeatmap, rawHeatmapLayout, plotlyConfig);
+Plotly.newPlot('plotly-spot-polar', fovHeatmap, fovHeatmapLayout, plotlyConfig);
 
 var pearsonTrace = [{
     x: [],
@@ -355,29 +358,6 @@ var pearsonLayout = {
 };
 Plotly.newPlot('plotly-pearson', pearsonTrace, pearsonLayout, plotlyConfig);
 
-var polarGuide = [{
-    type: 'scatterpolar',
-    r: [1],
-    theta: [45],
-    mode: 'markers',
-    marker: {size: 13, color: '#dc3545', symbol: 'x'},
-    name: 'Laser spot'
-}];
-var polarLayout = {
-    margin: {t: 20, r: 20, b: 20, l: 20},
-    polar: {
-        radialaxis: {visible: true, range: [0, 5]},
-        angularaxis: {
-            direction: 'clockwise',
-            rotation: 90,
-            tickmode: 'array',
-            tickvals: [0, 90, 180, 270],
-            ticktext: ['UP', 'RIGHT', 'DOWN', 'LEFT']
-        }
-    },
-    showlegend: false
-};
-Plotly.newPlot('plotly-spot-polar', polarGuide, polarLayout, plotlyConfig);
 
 function resizeAutoalignPlots() {
     ['plotly-lidar-signal', 'plotly-lidar-range-correction', 'plotly-pearson', 'plotly-spot-polar'].forEach(function(id) {

--- a/templates/autoalignment.html
+++ b/templates/autoalignment.html
@@ -7,48 +7,121 @@
 
     .autoalign-summary {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: .75rem;
+        grid-template-columns: repeat(5, minmax(120px, 1fr));
+        gap: .5rem;
     }
 
     .summary-box {
         border: 1px solid #dee2e6;
         border-radius: .25rem;
-        padding: .5rem .75rem;
+        padding: .45rem .6rem;
         background: #fff;
+        min-width: 0;
     }
 
     .summary-box .label {
         display: block;
         color: #6c757d;
-        font-size: .8rem;
+        font-size: .74rem;
+        white-space: nowrap;
     }
 
     .summary-box .value {
         font-weight: 700;
-        font-size: 1.1rem;
+        font-size: 1rem;
+        line-height: 1.2;
+        overflow-wrap: anywhere;
+    }
+
+    .autoalign-progress {
+        margin-top: .5rem;
+        display: grid;
+        grid-template-columns: minmax(160px, max-content) minmax(180px, 1fr) minmax(130px, max-content);
+        gap: .75rem;
+        align-items: center;
+        background: #fff;
+        border: 1px solid #dee2e6;
+        border-radius: .25rem;
+        padding: .45rem .6rem;
+    }
+
+    .autoalign-progress .progress {
+        height: .75rem;
+        min-width: 0;
+        width: 100%;
+    }
+
+    .scan-progress-label {
+        color: #6c757d;
+        font-size: .78rem;
+        white-space: nowrap;
+    }
+
+    .scan-progress-meta {
+        display: flex;
+        justify-content: flex-end;
+        align-items: baseline;
+        gap: .5rem;
+        min-width: 0;
+        white-space: nowrap;
+    }
+
+    .scan-status {
+        font-weight: 700;
+        color: #495057;
+    }
+
+    .scan-percent {
+        color: #6c757d;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .autoalign-plots {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1rem;
+        align-items: stretch;
+    }
+
+    .autoalign-card {
+        height: 100%;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .autoalign-card .card-body {
+        flex: 1 1 auto;
+        min-height: 0;
+        padding: .5rem;
     }
 
     .plot-host {
         width: 100%;
-        min-height: 300px;
-        height: 34vh;
-    }
-
-    .plot-host-square {
-        width: 100%;
-        aspect-ratio: 1 / 1;
-        min-height: 320px;
+        height: clamp(280px, 32vh, 420px);
+        min-width: 0;
     }
 
     @media (max-width: 992px) {
-        .plot-host {
-            min-height: 260px;
-            height: 36vh;
+        .autoalign-summary {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
         }
 
-        .plot-host-square {
-            min-height: 280px;
+        .autoalign-progress {
+            grid-template-columns: 1fr;
+            gap: .35rem;
+        }
+
+        .scan-progress-meta {
+            justify-content: space-between;
+        }
+
+        .autoalign-plots {
+            grid-template-columns: 1fr;
+        }
+
+        .plot-host {
+            height: clamp(260px, 42vh, 380px);
         }
     }
 </style>
@@ -208,47 +281,96 @@
     </ul>
 </li>
 
-<!-- Autoalignment controls -->
+<!-- Scanning controls -->
 <li class="nav-item has-treeview menu-closed">
     <a href="#" class="nav-link ">
         <i class="nav-icon fas fa-crosshairs"></i>
-        <p>Autoalignment setup<i class="right fas fa-angle-left"></i></p>
+        <p>Scanning setup<i class="right fas fa-angle-left"></i></p>
     </a>
     <ul class="nav nav-treeview">
         <li class="nav-item">
+            <label><b style="color:white">Grid XY:</b></label>
             <div class="form-row align-items-center">
                 <div class="col-sm-8 my-1">
                     <div class="input-group">
-                        <div class="input-group-prepend"><div class="input-group-text">r*</div></div>
-                        <input type="text" class="form-control" id="pearson_target_input" placeholder="Target Pearson">
+                        <div class="input-group-prepend"><div class="input-group-text">Rows</div></div>
+                        <input type="number" min="3" step="1" class="form-control" id="scan_rows_input" placeholder="Rows">
                     </div>
                 </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_rows_apply" value="scan_rows">Apply</button></div>
             </div>
             <div class="form-row align-items-center">
                 <div class="col-sm-8 my-1">
                     <div class="input-group">
-                        <div class="input-group-prepend"><div class="input-group-text">N</div></div>
-                        <input type="text" class="form-control" id="max_iter_input" placeholder="Max iterations">
+                        <div class="input-group-prepend"><div class="input-group-text">Cols</div></div>
+                        <input type="number" min="3" step="1" class="form-control" id="scan_cols_input" placeholder="Cols">
                     </div>
                 </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_cols_apply" value="scan_cols">Apply</button></div>
             </div>
-            <label><b style="color:white">Correlation range [m]:</b></label>
+            <label><b style="color:white">Motion:</b></label>
             <div class="form-row align-items-center">
-                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="corr_range_init_input" placeholder="Initial"></div>
-                <div class="col-sm-4 my-1"><input type="text" class="form-control" id="corr_range_final_input" placeholder="Final"></div>
-                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="corr_range_apply" value="corr_range">Apply</button></div>
+                <div class="col-sm-4 my-1"><input type="number" min="0.001" step="0.001" class="form-control" id="scan_step_x_input" placeholder="Step X [mm]"></div>
+                <div class="col-sm-4 my-1"><input type="number" min="0.001" step="0.001" class="form-control" id="scan_step_y_input" placeholder="Step Y [mm]"></div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_steps_apply" value="scan_steps">Apply</button></div>
             </div>
             <div class="form-row align-items-center">
                 <div class="col-sm-8 my-1">
                     <div class="input-group">
                         <div class="input-group-prepend"><div class="input-group-text">Δ grid</div></div>
-                        <input type="text" class="form-control" id="grid_min_resolution_input" placeholder="Min resolution between points">
+                        <input type="number" min="1" step="1" class="form-control" id="scan_feed_input" placeholder="Feed">
                     </div>
                 </div>
-                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="grid_min_resolution_apply" value="grid_min_resolution">Apply</button></div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_feed_apply" value="scan_feed">Apply</button></div>
             </div>
-            <small style="color:#ced4da;">Se requiere una resolución mínima entre puntos consecutivos para muestreo en grilla X/Y.</small>
-            <br>
+            <label><b style="color:white">Scan mode:</b></label>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">Pattern</div></div>
+                        <select class="form-control" id="scan_pattern_input">
+                            <option value="raster">raster</option>
+                            <option value="zigzag">zigzag</option>
+                            <option value="spiral">spiral</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_pattern_apply" value="scan_pattern">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">Reverse</div></div>
+                        <select class="form-control" id="scan_reverse_input">
+                            <option value="false">OFF</option>
+                            <option value="true">ON</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_reverse_apply" value="scan_reverse">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">Delay [s]</div></div>
+                        <input type="number" min="0" step="0.001" class="form-control" id="scan_delay_input" placeholder="Delay">
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_delay_apply" value="scan_delay">Apply</button></div>
+            </div>
+            <div class="form-row align-items-center">
+                <div class="col-sm-8 my-1">
+                    <div class="input-group">
+                        <div class="input-group-prepend"><div class="input-group-text">On fail</div></div>
+                        <select class="form-control" id="scan_on_fail_input">
+                            <option value="retry">retry</option>
+                            <option value="skip">skip</option>
+                            <option value="abort">abort</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="col-sm-2 my-1"><button type="submit" class="btn btn-primary" id="scan_on_fail_apply" value="scan_on_fail">Apply</button></div>
+            </div>
             <button type="button" class="btn btn-outline-success btn-sm" id="autoalign_start_btn" value="autoalign_start">START AUTOALIGN</button>
             <button type="button" class="btn btn-outline-danger btn-sm" id="autoalign_stop_btn" value="autoalign_stop">STOP</button>
         </li>
@@ -259,54 +381,71 @@
 {% block my_content %}
 <div class="container-fluid pt-2">
     <div class="row mb-2">
-        <div class="col-md-6">
+        <div class="col-12">
             <div class="autoalign-summary">
                 <div class="summary-box">
-                    <span class="label">Pearson actual</span>
-                    <span class="value" id="pearson_current_value">--</span>
+                    <span class="label">Grid size</span>
+                    <span class="value" id="grid_size_value">8 x 8</span>
                 </div>
                 <div class="summary-box">
-                    <span class="label">Mejor Pearson</span>
-                    <span class="value" id="pearson_best_value">--</span>
+                    <span class="label">Current X</span>
+                    <span class="value" id="grid_current_x_value">4.5</span>
                 </div>
                 <div class="summary-box">
                     <span class="label">Posición X (left/right)</span>
-                    <span class="value" id="motor_x_value">0</span>
+                    <span class="value" id="grid_current_y_value">4.5</span>
                 </div>
                 <div class="summary-box">
                     <span class="label">Posición Y (up/down)</span>
-                    <span class="value" id="motor_y_value">0</span>
+                    <span class="value" id="pearson_max_value">--</span>
+                </div>
+                <div class="summary-box">
+                    <span class="label">PC location</span>
+                    <span class="value" id="pearson_best_location_value">--</span>
+                </div>
+            </div>
+            <div class="autoalign-progress">
+                <span class="scan-progress-label">LiDAR scan progress</span>
+                <div class="progress">
+                    <div class="progress-bar bg-info"
+                         id="scan_progress_bar"
+                         role="progressbar"
+                         style="width: 0%;"
+                         aria-valuenow="0"
+                         aria-valuemin="0"
+                         aria-valuemax="100"></div>
+                </div>
+                <div class="scan-progress-meta">
+                    <span class="scan-status" id="scan_status_value">Idle</span>
+                    <span class="scan-percent" id="scan_progress_percent">0%</span>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="row">
-        <div class="col-md-6">
+    <div class="autoalign-plots">
+        <div class="autoalign-plot-cell">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Range corrected LiDAR signal</b></div>
-                <div class="card-body"><div id="plotly-lidar-range-correction" class="plot-host-square"></div></div>
+                <div class="card-body"><div id="plotly-lidar-range-correction" class="plot-host"></div></div>
             </div>
         </div>
-        <div class="col-md-6">
+        <div class="autoalign-plot-cell">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Pearson coefficient evolution</b></div>
                 <div class="card-body"><div id="plotly-pearson" class="plot-host"></div></div>
             </div>
         </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-6">
+        <div class="autoalign-plot-cell">
             <div class="card autoalign-card">
                 <div class="card-header"><b>Raw LiDAR signal</b></div>
-                <div class="card-body"><div id="plotly-lidar-signal" class="plot-host-square"></div></div>
+                <div class="card-body"><div id="plotly-lidar-signal" class="plot-host"></div></div>
             </div>
         </div>
-        <div class="col-md-6">
+        <div class="autoalign-plot-cell">
             <div class="card autoalign-card">
-                <div class="card-header"><b>Laser spot in telescope FOV (guide heatmap)</b></div>
-                <div class="card-body"><div id="plotly-spot-polar" class="plot-host"></div></div>
+                <div class="card-header"><b>LiDAR measurement grid</b></div>
+                <div class="card-body"><div id="plotly-measurement-grid" class="plot-host"></div></div>
             </div>
         </div>
     </div>
@@ -315,34 +454,110 @@
 <script>
 var correctedGraph = {{ context.plot_lidar_range_correction | safe }};
 var plotlyConfig = {responsive: true, displaylogo: false};
-var standardMargins = {t: 28, r: 24, b: 48, l: 56};
+var standardMargins = {t: 18, r: 16, b: 42, l: 52};
+var rangeCorrectedMargins = {t: 104, r: 24, b: 64, l: 64};
+var rawSignalMargins = {t: 32, r: 24, b: 56, l: 64};
 
-Plotly.newPlot('plotly-lidar-range-correction', correctedGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
+function responsiveLayout(baseLayout, overrides) {
+    var layout = Object.assign({}, baseLayout || {}, overrides || {});
+    delete layout.width;
+    delete layout.height;
+    layout.autosize = true;
+    return layout;
+}
+
+function drawResponsivePlot(targetId, figure, layoutOverrides) {
+    var traces = Array.isArray(figure) ? figure : (figure.data || []);
+    var layout = responsiveLayout(Array.isArray(figure) ? {} : figure.layout, layoutOverrides);
+    Plotly.newPlot(targetId, traces, layout, plotlyConfig);
+}
+
+drawResponsivePlot('plotly-lidar-range-correction', correctedGraph, {
+    margin: rangeCorrectedMargins
+});
 
 var signalGraph = {{ context.plot_lidar_signal | safe }};
-Plotly.newPlot('plotly-lidar-signal', signalGraph, {autosize: true, margin: standardMargins}, plotlyConfig);
+drawResponsivePlot('plotly-lidar-signal', signalGraph, {
+    title: null,
+    margin: rawSignalMargins
+});
 
-var xGrid = [-2, -1, 0, 1, 2];
-var yGrid = [-2, -1, 0, 1, 2];
-var zGrid = yGrid.map(function() { return xGrid.map(function() { return null; }); });
-var fovHeatmap = [{
+var measurementGridSize = 8;
+var measurementAxis = Array.from({length: measurementGridSize}, function(_, index) { return index + 1; });
+var measurementGridCenter = (measurementGridSize + 1) / 2;
+
+function setSummaryBoxLabel(valueId, labelText) {
+    var valueEl = document.getElementById(valueId);
+    var labelEl = valueEl && valueEl.parentElement ? valueEl.parentElement.querySelector('.label') : null;
+    if (labelEl) {
+        labelEl.textContent = labelText;
+    }
+}
+
+function setScanProgress(percent) {
+    var progress = Math.max(0, Math.min(100, Number(percent) || 0));
+    var progressBar = document.getElementById('scan_progress_bar');
+    var progressPercent = document.getElementById('scan_progress_percent');
+    var progressText = progress + '%';
+    if (progressBar) {
+        progressBar.style.width = progressText;
+        progressBar.setAttribute('aria-valuenow', progress);
+    }
+    if (progressPercent) {
+        progressPercent.textContent = progressText;
+    }
+}
+
+function setScanStatus(status) {
+    var allowedStatuses = ['Idle', 'Running', 'Stopped', 'Complete', 'Error'];
+    var nextStatus = allowedStatuses.indexOf(status) >= 0 ? status : 'Idle';
+    var statusEl = document.getElementById('scan_status_value');
+    if (statusEl) {
+        statusEl.textContent = nextStatus;
+    }
+}
+
+setSummaryBoxLabel('grid_size_value', 'Grid size');
+setSummaryBoxLabel('grid_current_x_value', 'Current X');
+setSummaryBoxLabel('grid_current_y_value', 'Current Y');
+setSummaryBoxLabel('pearson_max_value', 'PC max');
+setSummaryBoxLabel('pearson_best_location_value', 'PC location');
+document.getElementById('grid_size_value').textContent = measurementGridSize + ' x ' + measurementGridSize;
+document.getElementById('grid_current_x_value').textContent = measurementGridCenter;
+document.getElementById('grid_current_y_value').textContent = measurementGridCenter;
+setScanStatus('Idle');
+setScanProgress(0);
+
+var measurementValues = measurementAxis.map(function(row) {
+    return measurementAxis.map(function(column) {
+        var distanceFromCenter = Math.hypot(row - measurementGridCenter, column - measurementGridCenter);
+        return Math.max(-1, Math.min(1, 1 - distanceFromCenter / 4));
+    });
+});
+var measurementGridTrace = [{
     type: 'heatmap',
-    x: xGrid,
-    y: yGrid,
-    z: zGrid,
+    x: measurementAxis,
+    y: measurementAxis,
+    z: measurementValues,
     colorscale: 'Viridis',
     zmin: -1,
     zmax: 1,
-    colorbar: {title: 'Pearson r'}
+    hovertemplate: 'Column %{x}<br>Row %{y}<br>Pearson r %{z:.3f}<extra></extra>',
+    colorbar: {title: 'Pearson r', len: 0.8}
 }];
-var fovHeatmapLayout = {
-    title: 'X/Y scan grid (Pearson map)',
-    margin: {t: 38, r: 24, b: 48, l: 56},
-    xaxis: {title: 'Motor X position', scaleanchor: 'y', scaleratio: 1},
-    yaxis: {title: 'Motor Y position'},
+var measurementGridLayout = {
+    margin: {t: 18, r: 24, b: 42, l: 52},
+    xaxis: {
+        title: 'Column',
+        dtick: 1,
+        constrain: 'domain',
+        scaleanchor: 'y',
+        scaleratio: 1
+    },
+    yaxis: {title: 'Row', dtick: 1, autorange: 'reversed'},
     autosize: true
 };
-Plotly.newPlot('plotly-spot-polar', fovHeatmap, fovHeatmapLayout, plotlyConfig);
+drawResponsivePlot('plotly-measurement-grid', measurementGridTrace, measurementGridLayout);
 
 var pearsonTrace = [{
     x: [],
@@ -352,15 +567,16 @@ var pearsonTrace = [{
     line: {color: '#17a2b8'}
 }];
 var pearsonLayout = {
-    margin: {t: 20, r: 20, b: 50, l: 50},
+    autosize: true,
+    margin: {t: 18, r: 16, b: 42, l: 52},
     yaxis: {title: 'r', range: [-1, 1]},
     xaxis: {title: 'Iteration'}
 };
-Plotly.newPlot('plotly-pearson', pearsonTrace, pearsonLayout, plotlyConfig);
+drawResponsivePlot('plotly-pearson', pearsonTrace, pearsonLayout);
 
 
 function resizeAutoalignPlots() {
-    ['plotly-lidar-signal', 'plotly-lidar-range-correction', 'plotly-pearson', 'plotly-spot-polar'].forEach(function(id) {
+    ['plotly-lidar-range-correction', 'plotly-pearson', 'plotly-lidar-signal', 'plotly-measurement-grid'].forEach(function(id) {
         var el = document.getElementById(id);
         if (el) {
             Plotly.Plots.resize(el);
@@ -370,6 +586,15 @@ function resizeAutoalignPlots() {
 
 window.addEventListener('resize', resizeAutoalignPlots);
 setTimeout(resizeAutoalignPlots, 150);
+
+if ('ResizeObserver' in window) {
+    var plotResizeObserver = new ResizeObserver(function() {
+        window.requestAnimationFrame(resizeAutoalignPlots);
+    });
+    document.querySelectorAll('.plot-host').forEach(function(el) {
+        plotResizeObserver.observe(el);
+    });
+}
 
 // Also refresh plot sizes after sidebar collapse/expand transitions
 document.addEventListener('click', function(event) {
@@ -393,10 +618,70 @@ document.getElementById('rc_limits_init_input').value = globalconfig["rc_limits_
 document.getElementById('rc_limits_final_input').value = globalconfig["rc_limits_final"];
 document.getElementById('raw_limits_init_input').value = globalconfig["raw_limits_init"];
 document.getElementById('raw_limits_final_input').value = globalconfig["raw_limits_final"];
-document.getElementById('pearson_target_input').value = "0.98";
-document.getElementById('max_iter_input').value = "25";
-document.getElementById('corr_range_init_input').value = globalconfig["corr_range_init"];
-document.getElementById('corr_range_final_input').value = globalconfig["corr_range_final"];
-document.getElementById('grid_min_resolution_input').value = globalconfig["grid_min_resolution"];
+document.getElementById('scan_rows_input').value = globalconfig["scan_rows"];
+document.getElementById('scan_cols_input').value = globalconfig["scan_cols"];
+document.getElementById('scan_step_x_input').value = Number(globalconfig["scan_step_x"]).toFixed(3);
+document.getElementById('scan_step_y_input').value = Number(globalconfig["scan_step_y"]).toFixed(3);
+document.getElementById('scan_feed_input').value = globalconfig["scan_feed"];
+document.getElementById('scan_pattern_input').value = globalconfig["scan_pattern"];
+document.getElementById('scan_reverse_input').value = String(Boolean(globalconfig["scan_reverse"]));
+document.getElementById('scan_delay_input').value = globalconfig["scan_delay"];
+document.getElementById('scan_on_fail_input').value = globalconfig["scan_on_fail"];
+document.getElementById('grid_size_value').textContent = globalconfig["scan_rows"] + ' x ' + globalconfig["scan_cols"];
+
+var scanFeedInputGroup = document.getElementById('scan_feed_input').closest('.input-group');
+if (scanFeedInputGroup) {
+    scanFeedInputGroup.querySelector('.input-group-text').textContent = 'Feed [mm/min]';
+}
+
+function applyScanSetting(buttonId, inputId) {
+    $('#' + buttonId).on('click', function () {
+        $.ajax({
+            url: "/scan_setup",
+            type: "GET",
+            contentType: 'application/json;charset=UTF-8',
+            data: {
+                'selected': document.getElementById(buttonId).value,
+                'input': document.getElementById(inputId).value
+            },
+            dataType:"json",
+            success: function (data) {
+                globalconfig = data;
+                document.getElementById('grid_size_value').textContent = data["scan_rows"] + ' x ' + data["scan_cols"];
+                console.log("SCAN SETUP APPLY", buttonId, data);
+            }
+        });
+    });
+}
+
+applyScanSetting('scan_rows_apply', 'scan_rows_input');
+applyScanSetting('scan_cols_apply', 'scan_cols_input');
+applyScanSetting('scan_feed_apply', 'scan_feed_input');
+applyScanSetting('scan_pattern_apply', 'scan_pattern_input');
+applyScanSetting('scan_reverse_apply', 'scan_reverse_input');
+applyScanSetting('scan_delay_apply', 'scan_delay_input');
+applyScanSetting('scan_on_fail_apply', 'scan_on_fail_input');
+
+$('#scan_steps_apply').on('click', function () {
+    $.ajax({
+        url: "/scan_setup",
+        type: "GET",
+        contentType: 'application/json;charset=UTF-8',
+        data: {
+            'selected': document.getElementById('scan_steps_apply').value,
+            'input': JSON.stringify([
+                document.getElementById('scan_step_x_input').value,
+                document.getElementById('scan_step_y_input').value
+            ])
+        },
+        dataType:"json",
+        success: function (data) {
+            globalconfig = data;
+            document.getElementById('scan_step_x_input').value = Number(data["scan_step_x"]).toFixed(3);
+            document.getElementById('scan_step_y_input').value = Number(data["scan_step_y"]).toFixed(3);
+            console.log("SCAN STEPS APPLY", data);
+        }
+    });
+});
 </script>
 {% endblock my_content %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -51,6 +51,11 @@ scratch. This page gets rid of all links and provides the needed markup only.
                         <button class="btn btn-outline-secondary" ata-toggle="button" aria-pressed="false" type="button">Acquisition Mode</button>
                     </a>
                 </li> 
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('autoalignment_mode') }}">
+                        <button class="btn btn-outline-info" data-toggle="button" aria-pressed="false" type="button">Autoalignment Mode</button>
+                    </a>
+                </li>
             </ul>
             <!-- Right navbar links -->
             <ul class="navbar-nav ml-auto">

--- a/utils/plotly_plot.py
+++ b/utils/plotly_plot.py
@@ -24,13 +24,16 @@ def plotly_lidar_signal(lidar_signal,limit_init,limit_final):
   fig = px.line(df, 
                 x=df.index, 
                 y=df['raw_signal'], 
-                title='LiDAR raw signal')
+                title='LiDAR raw signal'
+                )
   
   # Set axes titles
   fig.update_xaxes(rangeslider_visible=True,title_text="Height [m]")
   fig.update_yaxes(title_text="Raw signal [mV]",)
 
-  fig.update_layout(width=1200, height=500)
+  fig.update_layout(width=1200, height=500,
+                    title=None,
+                    margin=dict(t=32, r=24, b=56, l=64))
 
   plot_json = json.dumps(fig, cls=plotly.utils.PlotlyJSONEncoder)
   
@@ -86,14 +89,15 @@ def plotly_lidar_range_correction(lidar_signal,limit_init,limit_final,wavelength
       xanchor="right",
       x=0.93),
       title={
-      'text': '<span style="font-size: 20px;">Range corrected LiDAR signal </span><br><span style="font-size: 10px;">(click and drag)</span>',
+      'text': '<span style="font-size: 15px;">Range corrected LiDAR signal </span><br><span style="font-size: 10px;">(click and drag)</span>',
       'y': 0.97,
       'x': 0.45,
       'xanchor': 'center',
       'yanchor': 'top'},
       paper_bgcolor="#ffffff",
       plot_bgcolor="#ffffff",
-      width=640, height=480
+      width=640, height=480,
+      margin=dict(t=104, r=24, b=64, l=64)
       # width=800, height=600
   )
   # display rayleigh-fit range
@@ -125,11 +129,13 @@ def plotly_empty_signal(signal_type):
     df.columns=["bin","raw_signal"]
     fig = px.line(df, 
                   x='bin', 
-                  y=['raw_signal'], 
+                  y=['raw_signal'],
                   title='LiDAR raw signal')
     
     fig.update_xaxes(rangeslider_visible=True)
-    fig.update_layout(width=1200, height=500)
+    fig.update_layout(width=1200, height=500,
+                      title=None,
+                      margin=dict(t=32, r=24, b=56, l=64))
     plot_json = json.dumps(fig, cls=plotly.utils.PlotlyJSONEncoder)
 
   elif signal_type =="rms":
@@ -196,14 +202,15 @@ def plotly_empty_signal(signal_type):
         xanchor="right",
         x=0.93),
         title={
-        'text': '<span style="font-size: 20px;">Range corrected LiDAR signal </span><br><span style="font-size: 10px;">(click and drag)</span>',
+        'text': '<span style="font-size: 15px;">Range corrected LiDAR signal </span><br><span style="font-size: 10px;">(click and drag)</span>',
         'y': 0.97,
         'x': 0.45,
         'xanchor': 'center',
         'yanchor': 'top'},
         paper_bgcolor="#ffffff",
         plot_bgcolor="#ffffff",
-        width=640, height=480
+        width=640, height=480,
+        margin=dict(t=104, r=24, b=64, l=64)
         # width=800, height=600
     )
 


### PR DESCRIPTION
## Summary
- Add responsive Plotly rendering for Alignment, Autoalignment, and Acquisition modes by removing fixed layout sizing and resizing charts on viewport/sidebar/container changes.
- Add card framing to Alignment plots to match the Autoalignment chart presentation.
- Replace Autoalignment setup controls with Scanning setup fields and add validated `/scan_setup` handling for grid and scan-mode parameters.
- Add Autoalignment scan summary boxes, scan progress/status display, and an 8x8 LiDAR measurement grid placeholder.

## Testing
- `python -m py_compile run.py utils\plotly_plot.py`
- Verified `/alignment`, `/autoalignment`, and `/acquisition` return HTTP 200 locally.
- Verified `/scan_setup?selected=scan_rows&input=9` returns updated JSON locally.